### PR TITLE
Fix/add sync main dev ci

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,13 +1,13 @@
-# .github/workflows/publish.yml
-name: Publish to PyPI
+name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
-  publish:
-    name: Build and publish to PyPI
+  release:
+    name: Release with Semantic Release
     runs-on: ubuntu-latest
 
     steps:
@@ -18,15 +18,12 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install build tools
+      - name: Install dependencies
         run: |
-          pip install --upgrade build twine
+          pip install -e .[dev]
 
-      - name: Build the package
-        run: python -m build
-
-      - name: Publish to PyPI
+      - name: Run Semantic Release
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
+          PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release publish

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,28 @@
+name: Sync main into dev
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'daronprater'  # Optional: avoids forks doing this
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed to access all branches
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync main → dev
+        run: |
+          git checkout dev
+          git merge origin/main --no-ff -m "chore(sync): merge main into dev"
+          git push origin dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dev = [
     "black",
     "flake8",
     "mypy",
-    "pandas-stubs"
+    "pandas-stubs",
+    "python-semantic-release"
 ]
 
 [build-system]
@@ -31,3 +32,13 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
+
+[tool.semantic_release]
+version_variable = [
+  "hank/__init__.py:__version__"
+]
+upload_to_pypi = true
+build_command = "python -m build"
+branch = "main"
+changelog_file = "CHANGELOG.md"
+commit_parser = "angular"  # Conventional commits style


### PR DESCRIPTION
Added another CI workflow to sync main and dev once semantic versioning updates version in main. Doing this to keep them in sync automatically